### PR TITLE
More playbook edits + addition

### DIFF
--- a/Playbooks/AWS/ec2_info_and_spindown.yml
+++ b/Playbooks/AWS/ec2_info_and_spindown.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: localhost
+- name: Get Info on Instances and Shut Down an EC2 Instance
+  hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   # Run this playbook with -vvv at the end in
   # order to see the actual info
 
@@ -10,15 +11,15 @@
     instance_name: "🔐"
 
   tasks:
-  - name: Gather Information About All Instances
-    amazon.aws.ec2_instance_info:
-      filters:
-        availability-zone: 🔐  # Specify specific region, i.e. "us-east-1b"
-      region: "{{ region }}"
+    - name: Gather Information About All Instances
+      amazon.aws.ec2_instance_info:
+        filters:
+          availability-zone: 🔐  # Specify specific region, i.e. "us-east-1b"
+        region: "{{ region }}"
 
-  - name: Shut Down EC2 Instance
-    amazon.aws.ec2_instance:
-      name: "{{ instance_name }}"
-      region: "{{ region }}"
-      state: absent
-      wait_timeout: 3
+    - name: Shut Down EC2 Instance
+      amazon.aws.ec2_instance:
+        name: "{{ instance_name }}"
+        region: "{{ region }}"
+        state: absent
+        wait_timeout: 3

--- a/Playbooks/AWS/ec2_launching_working_version.yml
+++ b/Playbooks/AWS/ec2_launching_working_version.yml
@@ -38,5 +38,5 @@
         region: "{{ region }}"
         wait_timeout: 3
         tags:
-          Owner: "you@example.com"  # remove this before committing
+          Owner: "you@example.com"
           Persistent: false

--- a/Playbooks/AWS/ec2_launching_working_version.yml
+++ b/Playbooks/AWS/ec2_launching_working_version.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: localhost
+- name: Configure Security Group and Launch EC2 Instance
+  hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: true
   # Based on info found here: https://www.coachdevops.com/2024/01/ansible-playbook-for-provisioning-new.html
   # and here: https://medium.com/@a_tsai5/creating-an-ec2-instance-using-ansible-764cf70015f6
 
@@ -14,36 +15,28 @@
     security_group: "🔐"
 
   tasks:
-  - name: Configure Security Group for the Instance
-    amazon.aws.ec2_security_group:
-      name: "{{ security_group }}"
-      description: example-security-group
-      region: "{{ region }}"
-      rules:
-        - proto: tcp
-          from_port: 22
-          to_port: 22
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          from_port: 80
-          to_port: 80
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          from_port: 8080
-          to_port: 8080
-          cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          cidr_ip: 0.0.0.0/0
+    - name: Configure Security Group for the Instance
+      amazon.aws.ec2_security_group:
+        name: "{{ security_group }}"
+        description: example-security-group
+        region: "{{ region }}"
+        rules:
+          - proto: tcp
+            from_port: 22  # SSH
+            to_port: 22  # SSH
+            cidr_ip: 0.0.0.0/0
+        rules_egress:
+          - proto: all
+            cidr_ip: 0.0.0.0/0
 
-  - name: Create an EC2 Instance
-    amazon.aws.ec2_instance:
-      security_group: "{{ security_group }}"
-      name: "{{ instance_name }}"
-      instance_type: "{{ instance_type}}"
-      image_id: "{{ image }}"
-      region: "{{ region }}"
-      wait_timeout: 3
-      tags: 
-        Owner: "you@example.com"  # remove this before committing
-        Persistent: False
+    - name: Create an EC2 Instance
+      amazon.aws.ec2_instance:
+        security_group: "{{ security_group }}"
+        name: "{{ instance_name }}"
+        instance_type: "{{ instance_type }}"
+        image_id: "{{ image }}"
+        region: "{{ region }}"
+        wait_timeout: 3
+        tags:
+          Owner: "you@example.com"  # remove this before committing
+          Persistent: false

--- a/Playbooks/AWS/vpc_setup_and_teardown.yml
+++ b/Playbooks/AWS/vpc_setup_and_teardown.yml
@@ -1,0 +1,92 @@
+---
+- name: Setup VPC, Subnet, and Gateway in AWS, Create and Shut Down EC2 Instance
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    vpc_cidr:  # something like "10.0.0.0/16"
+    subnet_cidr:  # something like "10.0.1.0/24"
+    subnet_name: "example-subnet"
+    vpc_name: "example-vpc"
+    region: # put region of preference here
+    image_id: 🔐  # will be something like "ami-2394723423987"
+    image_name: "Example-Subnet-Gateway-Test"
+    instance_type: # put type of preference; t2.micro is good for testing
+    security_group: "example-security-group"
+
+  tasks:
+    - name: Create VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ vpc_name }}"
+        region: "{{ region }}"
+        state: present
+
+    - name: Display VPC ID
+      ansible.builtin.command:
+        aws ec2 describe-vpcs --filter Name=tag:Name,Values="{{ subnet_name }}" --region={{ region }} --query Vpcs[].VpcId --output text
+      register: vpc_id
+      changed_when: vpc_id.rc != 0
+
+    - name: Capture VPC ID
+      ansible.builtin.debug:
+        var: vpc_id.stdout
+
+    - name: Create Subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ subnet_cidr }}"
+        vpc_id: "{{ vpc_id.stdout }}"
+        region: "{{ region }}"
+        tags:
+          Name: "Playbook Test Subnet"
+        state: present
+
+    - name: Display Subnet ID
+      ansible.builtin.command:
+        aws ec2 describe-subnets --region="{{ region }}" --filter Name=tag:Name,Values="Playbook Test Subnet" --query Subnets[].SubnetId --output text
+      register: subnet_id
+      changed_when: subnet_id.rc != 0
+
+    - name: Capture Subnet ID
+      ansible.builtin.debug:
+        var: subnet_id.stdout
+
+    - name: Create Gateway
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id.stdout }}"
+        region: "{{ region }}"
+        state: present
+
+    - name: Configure Security Group for the Instance
+      amazon.aws.ec2_security_group:
+        name: "{{ security_group }}"
+        description: example-security-group
+        region: "{{ region }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 0.0.0.0/0
+        rules_egress:
+          - proto: all
+            cidr_ip: 0.0.0.0/0
+
+    - name: Create EC2 Instance in Gateway Subnet
+      amazon.aws.ec2_instance:
+        security_group: "{{ security_group }}"
+        name: "{{ image_name }}"
+        instance_type: "{{ instance_type }}"
+        image_id: "{{ image_id }}"
+        region: "{{ region }}"
+        wait_timeout: 3
+        tags:
+          Owner: "you@example.com"
+          Persistent: false
+
+    - name: Shut Down EC2 Instance
+      amazon.aws.ec2_instance:
+        name: "{{ image_name }}"
+        region: "{{ region }}"
+        state: absent
+        wait_timeout: 3


### PR DESCRIPTION
Ran [`ansible-lint`](https://ansible.readthedocs.io/projects/lint/) on some existing playbooks, adding another one that provisions a VPC, subnet, gateway and an EC2 instance and then shuts it down (need to edit in the future to utilize [`ec2_instance_info`](https://github.com/ansible-collections/amazon.aws/blob/main/plugins/modules/ec2_instance_info.py) module instead of [`ansible.builtin.command`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html) and also use [module default vars](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_module_defaults.html#module-defaults-groups) but that is a future to-do).